### PR TITLE
feat: add --author flag with @me support to pr list

### DIFF
--- a/cmd/pr_list.go
+++ b/cmd/pr_list.go
@@ -12,8 +12,9 @@ import (
 )
 
 var (
-	prListState string
-	prListLimit int
+	prListState  string
+	prListLimit  int
+	prListAuthor string
 )
 
 var prListCmd = &cobra.Command{
@@ -27,6 +28,7 @@ func init() {
 	prCmd.AddCommand(prListCmd)
 	prListCmd.Flags().StringVar(&prListState, "state", "OPEN", "PR state filter: OPEN, MERGED, DECLINED, SUPERSEDED")
 	prListCmd.Flags().IntVar(&prListLimit, "limit", 25, "Maximum number of PRs to display")
+	prListCmd.Flags().StringVarP(&prListAuthor, "author", "A", "", "Filter by author nickname (use @me for yourself)")
 }
 
 func runPRList(cmd *cobra.Command, args []string) error {
@@ -44,7 +46,21 @@ func runPRList(cmd *cobra.Command, args []string) error {
 	}
 
 	client := api.NewClient(cfg.Username, cfg.Token)
-	prs, err := client.ListPullRequests(workspace, repo, prListState, prListLimit)
+
+	var query string
+	if prListAuthor != "" {
+		author := prListAuthor
+		if author == "@me" {
+			user, err := client.GetCurrentUser()
+			if err != nil {
+				return fmt.Errorf("failed to resolve @me: %w", err)
+			}
+			author = user.Nickname
+		}
+		query = fmt.Sprintf(`author.nickname="%s"`, author)
+	}
+
+	prs, err := client.ListPullRequests(workspace, repo, prListState, prListLimit, query)
 	if err != nil {
 		return fmt.Errorf("failed to list pull requests: %w", err)
 	}

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -97,9 +97,35 @@ func (c *Client) Post(path string, body interface{}, target interface{}) error {
 	return c.do(req, target)
 }
 
+func (c *Client) GetRaw(path string) (string, error) {
+	req, err := c.newRequest(http.MethodGet, path, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", "text/plain")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		return "", fmt.Errorf("API error (%d): %s", resp.StatusCode, string(data))
+	}
+
+	return string(data), nil
+}
+
 type CurrentUser struct {
 	DisplayName string `json:"display_name"`
 	Username    string `json:"username"`
+	Nickname    string `json:"nickname"`
 	UUID        string `json:"uuid"`
 	AccountID   string `json:"account_id"`
 }

--- a/internal/api/pullrequests.go
+++ b/internal/api/pullrequests.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"fmt"
+	"net/url"
 
 	"github.com/zoldyzdk/bb-cli/internal/models"
 )
@@ -10,8 +11,11 @@ func repoPath(workspace, repo string) string {
 	return fmt.Sprintf("/repositories/%s/%s", workspace, repo)
 }
 
-func (c *Client) ListPullRequests(workspace, repo, state string, limit int) ([]models.PullRequest, error) {
+func (c *Client) ListPullRequests(workspace, repo, state string, limit int, query string) ([]models.PullRequest, error) {
 	path := fmt.Sprintf("%s/pullrequests?state=%s&pagelen=%d", repoPath(workspace, repo), state, limit)
+	if query != "" {
+		path += "&q=" + url.QueryEscape(query)
+	}
 
 	var result models.PaginatedResponse[models.PullRequest]
 	if err := c.Get(path, &result); err != nil {


### PR DESCRIPTION
## Summary

- Adds `--author` / `-A` flag to `bb pr list` that filters PRs by author nickname using Bitbucket's query API (`q=author.nickname="<value>"`)
- Supports `@me` to resolve to the authenticated user's nickname via `GET /user`
- Adds `Nickname` field to `CurrentUser` struct
- Preserves existing behavior when `--author` is not provided

Closes #2

## Test plan

- [ ] `bb pr list --author <nickname>` returns only PRs from that author
- [ ] `bb pr list --author @me` resolves to current user and filters
- [ ] `bb pr list` without `--author` shows all PRs (unchanged behavior)
- [ ] `--author` works with `--state` and `--limit` flags
- [ ] `@me` without authentication shows clear error


Made with [Cursor](https://cursor.com)