### PR TITLE
feat: add pr checkout command

### DIFF
--- a/cmd/git_ops.go
+++ b/cmd/git_ops.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+func gitFetch(remote, remoteBranch, localBranch string, force bool) error {
+	refspec := fmt.Sprintf("%s:%s", remoteBranch, localBranch)
+	args := []string{"fetch", remote, refspec}
+	if force {
+		args = append(args, "--force")
+	}
+
+	cmd := exec.Command("git", args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("git fetch failed: %w", err)
+	}
+	return nil
+}
+
+func gitCheckout(branch string) error {
+	cmd := exec.Command("git", "checkout", branch)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("git checkout failed: %w", err)
+	}
+	return nil
+}

--- a/cmd/pr_checkout.go
+++ b/cmd/pr_checkout.go
@@ -1,0 +1,71 @@
+package cmd
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"github.com/zoldyzdk/bb-cli/internal/api"
+	"github.com/zoldyzdk/bb-cli/internal/config"
+)
+
+var (
+	prCheckoutBranch string
+	prCheckoutForce  bool
+)
+
+var prCheckoutCmd = &cobra.Command{
+	Use:   "checkout <pr-id>",
+	Short: "Check out a pull request branch",
+	Long:  `Fetch the source branch of a pull request and check it out locally.`,
+	Args:  cobra.ExactArgs(1),
+	RunE:  runPRCheckout,
+}
+
+func init() {
+	prCmd.AddCommand(prCheckoutCmd)
+	prCheckoutCmd.Flags().StringVarP(&prCheckoutBranch, "branch", "b", "", "Local branch name to use (defaults to PR source branch)")
+	prCheckoutCmd.Flags().BoolVarP(&prCheckoutForce, "force", "f", false, "Reset existing local branch to latest PR state")
+}
+
+func runPRCheckout(cmd *cobra.Command, args []string) error {
+	prID, err := strconv.Atoi(args[0])
+	if err != nil {
+		return fmt.Errorf("invalid PR ID: %s", args[0])
+	}
+
+	workspace, repo, err := resolveWorkspaceAndRepo()
+	if err != nil {
+		return err
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+	if !cfg.HasCredentials() {
+		return fmt.Errorf("not logged in. Run 'bb auth login' first")
+	}
+
+	client := api.NewClient(cfg.Username, cfg.Token)
+	pr, err := client.GetPullRequest(workspace, repo, prID)
+	if err != nil {
+		return fmt.Errorf("failed to get pull request: %w", err)
+	}
+
+	localBranch := pr.Source.Branch.Name
+	if prCheckoutBranch != "" {
+		localBranch = prCheckoutBranch
+	}
+
+	if err := gitFetch("origin", pr.Source.Branch.Name, localBranch, prCheckoutForce); err != nil {
+		return err
+	}
+
+	if err := gitCheckout(localBranch); err != nil {
+		return err
+	}
+
+	fmt.Printf("Switched to branch '%s' (PR #%d: %s)\n", localBranch, pr.ID, pr.Title)
+	return nil
+}


### PR DESCRIPTION
## Summary

- Adds `bb pr checkout <pr-id>` command that fetches a PR's source branch and checks it out locally
- Creates a git operations module (`cmd/git_ops.go`) with `gitFetch` and `gitCheckout` helpers using `os/exec`
- Supports `--branch` / `-b` to override the local branch name (defaults to PR source branch)
- Supports `--force` / `-f` to reset an existing local branch to the latest PR state

Closes #3

## Test plan

- [ ] `bb pr checkout <id>` fetches and checks out the PR's source branch
- [ ] Local branch defaults to the PR's source branch name
- [ ] `--branch my-name` uses custom local branch name
- [ ] `--force` resets an existing branch
- [ ] Invalid PR ID shows clear error
- [ ] Missing auth shows clear error


Made with [Cursor](https://cursor.com)