### PR TITLE
feat: add pr diff command with --name-only

### DIFF
--- a/cmd/pr_diff.go
+++ b/cmd/pr_diff.go
@@ -1,0 +1,93 @@
+package cmd
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/zoldyzdk/bb-cli/internal/api"
+	"github.com/zoldyzdk/bb-cli/internal/config"
+)
+
+var prDiffNameOnly bool
+
+var prDiffCmd = &cobra.Command{
+	Use:   "diff <pr-id>",
+	Short: "View the diff of a pull request",
+	Long:  `Display the diff of a pull request. Shows the raw unified diff by default.`,
+	Args:  cobra.ExactArgs(1),
+	RunE:  runPRDiff,
+}
+
+func init() {
+	prCmd.AddCommand(prDiffCmd)
+	prDiffCmd.Flags().BoolVar(&prDiffNameOnly, "name-only", false, "Display only names of changed files")
+}
+
+func runPRDiff(cmd *cobra.Command, args []string) error {
+	prID, err := strconv.Atoi(args[0])
+	if err != nil {
+		return fmt.Errorf("invalid PR ID: %s", args[0])
+	}
+
+	workspace, repo, err := resolveWorkspaceAndRepo()
+	if err != nil {
+		return err
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+	if !cfg.HasCredentials() {
+		return fmt.Errorf("not logged in. Run 'bb auth login' first")
+	}
+
+	client := api.NewClient(cfg.Username, cfg.Token)
+	diff, err := client.GetPullRequestDiff(workspace, repo, prID)
+	if err != nil {
+		return fmt.Errorf("failed to get pull request diff: %w", err)
+	}
+
+	if prDiffNameOnly {
+		for _, name := range extractFileNames(diff) {
+			fmt.Println(name)
+		}
+		return nil
+	}
+
+	fmt.Print(diff)
+	return nil
+}
+
+func extractFileNames(diff string) []string {
+	seen := make(map[string]bool)
+	var files []string
+
+	lines := strings.Split(diff, "\n")
+	for i, line := range lines {
+		if !strings.HasPrefix(line, "+++ ") {
+			continue
+		}
+		if strings.HasPrefix(line, "+++ /dev/null") {
+			if i > 0 && strings.HasPrefix(lines[i-1], "--- a/") {
+				name := strings.TrimPrefix(lines[i-1], "--- a/")
+				if !seen[name] {
+					seen[name] = true
+					files = append(files, name)
+				}
+			}
+			continue
+		}
+		if strings.HasPrefix(line, "+++ b/") {
+			name := strings.TrimPrefix(line, "+++ b/")
+			if !seen[name] {
+				seen[name] = true
+				files = append(files, name)
+			}
+		}
+	}
+
+	return files
+}

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -97,6 +97,31 @@ func (c *Client) Post(path string, body interface{}, target interface{}) error {
 	return c.do(req, target)
 }
 
+func (c *Client) GetRaw(path string) (string, error) {
+	req, err := c.newRequest(http.MethodGet, path, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", "text/plain")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode >= 400 {
+		return "", fmt.Errorf("API error (%d): %s", resp.StatusCode, string(data))
+	}
+
+	return string(data), nil
+}
+
 type CurrentUser struct {
 	DisplayName string `json:"display_name"`
 	Username    string `json:"username"`

--- a/internal/api/pullrequests.go
+++ b/internal/api/pullrequests.go
@@ -53,3 +53,8 @@ func (c *Client) ListPullRequestComments(workspace, repo string, prID, limit int
 
 	return result.Values, nil
 }
+
+func (c *Client) GetPullRequestDiff(workspace, repo string, prID int) (string, error) {
+	path := fmt.Sprintf("%s/pullrequests/%d/diff", repoPath(workspace, repo), prID)
+	return c.GetRaw(path)
+}


### PR DESCRIPTION
## Summary

- Adds `bb pr diff <pr-id>` command that retrieves and displays the raw unified diff from the Bitbucket API
- Adds `GetRaw` method to the API client for non-JSON endpoints (returns raw response body as string)
- Adds `GetPullRequestDiff` API method calling `GET /repositories/{w}/{r}/pullrequests/{id}/diff`
- Supports `--name-only` flag to display only changed file paths (parses unified diff format)

Closes #4

## Test plan

- [ ] `bb pr diff <id>` outputs raw unified diff
- [ ] `bb pr diff <id> --name-only` outputs only file paths (one per line)
- [ ] Handles deleted files (extracts from `--- a/` when `+++ /dev/null`)
- [ ] Invalid PR ID shows clear error
- [ ] Missing auth shows clear error


Made with [Cursor](https://cursor.com)